### PR TITLE
Fix: crash of ProxyService when restart

### DIFF
--- a/app/src/main/java/io/github/trojan_gfw/igniter/ProxyService.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/ProxyService.java
@@ -401,7 +401,7 @@ public class ProxyService extends VpnService implements TestConnection.OnResultL
                 .setAutoCancel(false)
                 .setOngoing(true);
         startForeground(IGNITER_STATUS_NOTIFY_MSG_ID, builder.build());
-        return START_STICKY;
+        return START_REDELIVER_INTENT;
     }
 
     private void shutdown() {


### PR DESCRIPTION
Fix: https://github.com/trojan-gfw/igniter/issues/200

ref: https://android-developers.googleblog.com/2010/02/service-api-changes-starting-with.html
```
Once you start targeting API version 5 or later, the default mode is START_STICKY 
and you must be prepared to deal with onStart() or onStartCommand() being called 
with a null Intent.
```