### PR TITLE
Fix: crash caused by lacking of system icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ proguard/
 
 # Android Studio Navigation editor temp files
 .navigation/
+.project
+.settings/
 
 # Android Studio captures folder
 captures/

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/action_save_profile"
-        android:icon="@android:drawable/ic_menu_save"
+        android:icon="@drawable/ic_save"
         android:orderInCategory="10"
         android:title="@string/action_save_profile" />
     <item


### PR DESCRIPTION
Fix https://github.com/trojan-gfw/igniter/issues/198
App crash at startup on some devices.

The traceback provided in report is ambiguous, all we know is it happened during loading some icon and it's about MenuItem. 

```
 ➜  igniter ag icon=
app/src/main/AndroidManifest.xml
15:        android:icon="@mipmap/ic_launcher"
17:        android:roundIcon="@mipmap/ic_launcher_round"
58:            android:icon="@drawable/ic_tile"

app/src/main/res/menu/menu_exempt_app.xml
6:        android:icon="@drawable/ic_search"
13:        android:icon="@drawable/ic_save"

app/src/main/res/menu/menu_main.xml
6:        android:icon="@android:drawable/ic_menu_save"
22:        android:icon="@drawable/ic_action_name"
33:        android:icon="@drawable/ic_action_link"

app/src/main/res/menu/menu_server_list.xml
6:        android:icon="@drawable/qr_code"
```
`@android:drawable/ic_menu_save`
