### PR TITLE
Fix Google Play account verification issue

### DIFF
--- a/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
@@ -621,10 +621,10 @@ public class MainActivity extends AppCompatActivity implements TrojanConnection.
                     startActivityForResult(ExemptAppActivity.create(this), EXEMPT_APP_CONFIGURE_REQUEST_CODE);
                 } else {
                     if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                        SnackbarUtils.showTextLong(rootViewGroup, R.string.main_exempt_feature_permission_requirement);
+                    } else {
                         ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE,
                                 Manifest.permission.WRITE_EXTERNAL_STORAGE}, READ_WRITE_EXT_STORAGE_PERMISSION_REQUEST);
-                    } else {
-                        SnackbarUtils.showTextLong(rootViewGroup, R.string.main_exempt_feature_permission_requirement);
                     }
                 }
                 return true;

--- a/app/src/main/res/raw/clash_config.yaml
+++ b/app/src/main/res/raw/clash_config.yaml
@@ -56,6 +56,10 @@ rules:
   ## 您可以在此处插入您补充的自定义规则（请注意保持缩进）
   # Chinese ROM uses googleapis.cn, which is broken
   - DOMAIN-KEYWORD,googleapis,Proxy
+  - DOMAIN,services.googleapis.cn,Proxy
+  - DOMAIN,services.googleapis.com,Proxy
+  - DOMAIN,www.googleapis.com,Proxy
+  - DOMAIN,www.googleapis.cn,Proxy
 
 # 国内网站
   - DOMAIN,cdn.hockeyapp.net,DIRECT


### PR DESCRIPTION
Force loading services.googleapis.cn, services.googleapis.com, www.googleapis.com and www.googleapis.cn through proxy. Fix the issue that sometimes user cannot use Google Play due to the failure of Google account verification.
I test it on my phones and found it works well.