### PR TITLE
Fix ArrayIndexOutOfBoundsException

### DIFF
--- a/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
@@ -542,6 +542,7 @@ public class MainActivity extends AppCompatActivity implements TrojanConnection.
                         remoteAddrText.setText(config.getRemoteAddr());
                         remotePortText.setText(String.valueOf(config.getRemotePort()));
                         passwordText.setText(config.getPassword());
+                        TrojanHelper.WriteTrojanConfig(Globals.getTrojanConfigInstance(), Globals.getTrojanConfigPath());
                     }
                 });
                 shareLink = TrojanURLHelper.GenerateTrojanURL(config);

--- a/app/src/main/java/io/github/trojan_gfw/igniter/servers/fragment/ServerListAdapter.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/servers/fragment/ServerListAdapter.java
@@ -43,7 +43,6 @@ public class ServerListAdapter extends RecyclerView.Adapter<ViewHolder> {
     public void removeItemOnPosition(int pos) {
         mData.remove(pos);
         notifyItemRemoved(pos);
-        notifyDataSetChanged();
     }
 
     @Override
@@ -86,8 +85,9 @@ class ViewHolder extends RecyclerView.ViewHolder {
         itemView.findViewById(R.id.deleteServerBtn).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (itemClickListener != null) {
-                    itemClickListener.onItemDelete(mConfig, getBindingAdapterPosition());
+                int position = getBindingAdapterPosition();
+                if (position != RecyclerView.NO_POSITION && itemClickListener != null) {
+                    itemClickListener.onItemDelete(mConfig, position);
                 }
             }
         });

--- a/app/src/main/java/io/github/trojan_gfw/igniter/servers/fragment/ServerListAdapter.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/servers/fragment/ServerListAdapter.java
@@ -43,6 +43,7 @@ public class ServerListAdapter extends RecyclerView.Adapter<ViewHolder> {
     public void removeItemOnPosition(int pos) {
         mData.remove(pos);
         notifyItemRemoved(pos);
+        notifyDataSetChanged();
     }
 
     @Override


### PR DESCRIPTION
**fix ArrayIndexOutOfBoundsException, when click the delete button to delete server item as fast as possible.**
```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.github.trojan_gfw.igniter.debug, PID: 4367
    java.lang.ArrayIndexOutOfBoundsException: length=3; index=-1
        at java.util.ArrayList.remove(ArrayList.java:480)
        at io.github.trojan_gfw.igniter.servers.fragment.ServerListAdapter.removeItemOnPosition(ServerListAdapter.java:44)
        at io.github.trojan_gfw.igniter.servers.fragment.ServerListFragment$9.run(ServerListFragment.java:286)
        at android.os.Handler.handleCallback(Handler.java:751)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6077)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:866)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:756)
```