### PR TITLE
Block mode and allow mode for exempt application list

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ private String GenerateVersionName() {
 }
 
 android {
-    ndkVersion '21.0.6113669'
+    ndkVersion "21.3.6528147"
     compileSdkVersion 28
 
     applicationVariants.all { variant ->

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ private String GenerateVersionName() {
 }
 
 android {
-    ndkVersion "21.3.6528147"
+    ndkVersion '21.0.6113669'
     compileSdkVersion 28
 
     applicationVariants.all { variant ->
@@ -63,6 +63,10 @@ android {
         cmake {
             path file('src/main/cpp/CMakeLists.txt')
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,8 +5,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application xmlns:tools="http://schemas.android.com/tools"

--- a/app/src/main/java/io/github/trojan_gfw/igniter/Globals.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/Globals.java
@@ -9,15 +9,11 @@ public class Globals {
 
     private static String cacheDir;
     private static String filesDir;
-    private static String externalFilesDir;
     private static TrojanConfig trojanConfigInstance;
 
     public static void Init(Context ctx) {
         cacheDir = ctx.getCacheDir().getAbsolutePath();
         filesDir = ctx.getFilesDir().getAbsolutePath();
-        File externalDocDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS);
-        File igniterExternalFileDir = new File(externalDocDir, "igniter");
-        externalFilesDir = igniterExternalFileDir.getAbsolutePath();
         trojanConfigInstance = new TrojanConfig();
         trojanConfigInstance.setCaCertPath(Globals.getCaCertPath());
     }
@@ -46,15 +42,7 @@ public class Globals {
         return PathHelper.combine(filesDir, "preferences.txt");
     }
 
-    /**
-     * @deprecated use {@link #getInternalBlockAppListPath()} instead.
-     */
-    @Deprecated
-    public static String getExternalExemptedAppListPath() {
-        return PathHelper.combine(externalFilesDir, "exempted_app_list.txt");
-    }
-
-    public static String getInternalBlockAppListPath() {
+    public static String getBlockedAppListPath() {
         return PathHelper.combine(filesDir, "exempted_app_list.txt");
     }
 

--- a/app/src/main/java/io/github/trojan_gfw/igniter/Globals.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/Globals.java
@@ -47,15 +47,19 @@ public class Globals {
     }
 
     /**
-     * @deprecated use {@link #getInternalExemptedAppListPath()} instead.
+     * @deprecated use {@link #getInternalBlockAppListPath()} instead.
      */
     @Deprecated
     public static String getExternalExemptedAppListPath() {
         return PathHelper.combine(externalFilesDir, "exempted_app_list.txt");
     }
 
-    public static String getInternalExemptedAppListPath() {
+    public static String getInternalBlockAppListPath() {
         return PathHelper.combine(filesDir, "exempted_app_list.txt");
+    }
+
+    public static String getAllowedAppListPath() {
+        return PathHelper.combine(filesDir, "allow_app_list.txt");
     }
 
     public static void setTrojanConfigInstance(TrojanConfig config) {

--- a/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
@@ -38,13 +38,10 @@ import java.io.InputStream;
 import io.github.trojan_gfw.igniter.common.constants.Constants;
 import io.github.trojan_gfw.igniter.common.os.Task;
 import io.github.trojan_gfw.igniter.common.os.Threads;
-import io.github.trojan_gfw.igniter.common.utils.PermissionUtils;
 import io.github.trojan_gfw.igniter.common.utils.PreferenceUtils;
 import io.github.trojan_gfw.igniter.common.utils.SnackbarUtils;
 import io.github.trojan_gfw.igniter.connection.TrojanConnection;
 import io.github.trojan_gfw.igniter.exempt.activity.ExemptAppActivity;
-import io.github.trojan_gfw.igniter.exempt.data.ExemptAppDataManager;
-import io.github.trojan_gfw.igniter.exempt.data.ExemptAppDataSource;
 import io.github.trojan_gfw.igniter.proxy.aidl.ITrojanService;
 import io.github.trojan_gfw.igniter.servers.activity.ServerListActivity;
 import io.github.trojan_gfw.igniter.servers.data.ServerListDataManager;
@@ -347,20 +344,8 @@ public class MainActivity extends AppCompatActivity implements TrojanConnection.
                 PreferenceUtils.putBooleanPreference(getContentResolver(),
                         Uri.parse(Constants.PREFERENCE_URI),
                         Constants.PREFERENCE_KEY_FIRST_START, false);
-                migrateExternalExemptAppInfoImplicitly();
             }
         });
-    }
-
-    private void migrateExternalExemptAppInfoImplicitly() {
-        if (PermissionUtils.hasReadWriteExtStoragePermission(MainActivity.this)) {
-            ExemptAppDataSource dataSource = new ExemptAppDataManager(MainActivity.this,
-                    Globals.getInternalBlockAppListPath(), Globals.getExternalExemptedAppListPath(), Globals.getAllowedAppListPath());
-            if (dataSource.checkExternalExemptAppInfoConfigExistence()) {
-                dataSource.migrateExternalExemptAppInfo();
-                dataSource.deleteExternalExemptAppInfo();
-            }
-        }
     }
 
     @Override

--- a/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
@@ -1,7 +1,6 @@
 package io.github.trojan_gfw.igniter;
 
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipboardManager;
@@ -30,7 +29,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.ActivityCompat;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -357,7 +355,7 @@ public class MainActivity extends AppCompatActivity implements TrojanConnection.
     private void migrateExternalExemptAppInfoImplicitly() {
         if (PermissionUtils.hasReadWriteExtStoragePermission(MainActivity.this)) {
             ExemptAppDataSource dataSource = new ExemptAppDataManager(MainActivity.this,
-                    Globals.getInternalExemptedAppListPath(), Globals.getExternalExemptedAppListPath());
+                    Globals.getInternalBlockAppListPath(), Globals.getExternalExemptedAppListPath(), Globals.getAllowedAppListPath());
             if (dataSource.checkExternalExemptAppInfoConfigExistence()) {
                 dataSource.migrateExternalExemptAppInfo();
                 dataSource.deleteExternalExemptAppInfo();

--- a/app/src/main/java/io/github/trojan_gfw/igniter/ProxyService.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/ProxyService.java
@@ -212,8 +212,7 @@ public class ProxyService extends VpnService implements TestConnection.OnResultL
     private Set<String> getExemptAppPackageNames(boolean allowMode) {
         if (mExemptAppDataSource == null) {
             mExemptAppDataSource = new ExemptAppDataManager(getApplicationContext(),
-                    Globals.getInternalBlockAppListPath(), Globals.getExternalExemptedAppListPath(),
-                    Globals.getAllowedAppListPath());
+                    Globals.getBlockedAppListPath(), Globals.getAllowedAppListPath());
         }
         if (allowMode) {
             return mExemptAppDataSource.loadAllowAppPackageNameSet();
@@ -267,9 +266,10 @@ public class ProxyService extends VpnService implements TestConnection.OnResultL
         Set<String> exemptAppPackageNames = getExemptAppPackageNames(workInAllowMode);
         RuleApplier applier;
         if (workInAllowMode) {
+            exemptAppPackageNames.remove(getPackageName()); // disallow Igniter
             applier = Builder::addAllowedApplication;
         } else {
-            exemptAppPackageNames.add(getPackageName()); // disallowed Igniter
+            exemptAppPackageNames.add(getPackageName()); // disallow Igniter
             applier = Builder::addDisallowedApplication;
         }
         for (String packageName : exemptAppPackageNames) {

--- a/app/src/main/java/io/github/trojan_gfw/igniter/common/constants/Constants.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/common/constants/Constants.java
@@ -6,4 +6,5 @@ public abstract class Constants {
     public static final String PREFERENCE_URI = "content://" + PREFERENCE_AUTHORITY + "/" + PREFERENCE_PATH;
     public static final String PREFERENCE_KEY_ENABLE_CLASH = "enable_clash";
     public static final String PREFERENCE_KEY_FIRST_START = "first_start";
+    public static final String PREFERENCE_KEY_PROXY_IN_ALLOW_MODE = "proxy_allow_mode";
 }

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/activity/ExemptAppActivity.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/activity/ExemptAppActivity.java
@@ -33,7 +33,7 @@ public class ExemptAppActivity extends BaseAppCompatActivity {
             fragment = ExemptAppFragment.newInstance();
         }
         mPresenter = new ExemptAppPresenter(this, fragment, new ExemptAppDataManager(getApplicationContext(),
-                Globals.getInternalExemptedAppListPath(), Globals.getExternalExemptedAppListPath()));
+                Globals.getInternalBlockAppListPath(), Globals.getExternalExemptedAppListPath(), Globals.getAllowedAppListPath()));
         fm.beginTransaction()
                 .replace(R.id.parent_fl, fragment, ExemptAppFragment.TAG)
                 .commitAllowingStateLoss();

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/activity/ExemptAppActivity.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/activity/ExemptAppActivity.java
@@ -33,7 +33,7 @@ public class ExemptAppActivity extends BaseAppCompatActivity {
             fragment = ExemptAppFragment.newInstance();
         }
         mPresenter = new ExemptAppPresenter(this, fragment, new ExemptAppDataManager(getApplicationContext(),
-                Globals.getInternalBlockAppListPath(), Globals.getExternalExemptedAppListPath(), Globals.getAllowedAppListPath()));
+                Globals.getBlockedAppListPath(), Globals.getAllowedAppListPath()));
         fm.beginTransaction()
                 .replace(R.id.parent_fl, fragment, ExemptAppFragment.TAG)
                 .commitAllowingStateLoss();

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/contract/ExemptAppContract.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/contract/ExemptAppContract.java
@@ -22,10 +22,6 @@ public interface ExemptAppContract {
 
         void filterAppsByName(String name);
 
-        void ignoreExternalExemptedAppListConfigForever();
-
-        void migrateExternalExemptedAppListFileToPrivateDirectory();
-
         void loadBlockAppListConfig();
 
         void loadAllowAppListConfig();
@@ -34,8 +30,6 @@ public interface ExemptAppContract {
     }
 
     interface View extends BaseView<Presenter> {
-        @UiThread
-        void showExemptedAppListMigrationNotice();
 
         @UiThread
         void showLoading();

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/contract/ExemptAppContract.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/contract/ExemptAppContract.java
@@ -26,7 +26,9 @@ public interface ExemptAppContract {
 
         void migrateExternalExemptedAppListFileToPrivateDirectory();
 
-        void loadExemptedAppListConfig();
+        void loadBlockAppListConfig();
+
+        void loadAllowAppListConfig();
 
         void exit();
     }
@@ -48,7 +50,10 @@ public interface ExemptAppContract {
         void showExitConfirm();
 
         @UiThread
-        void showAppList(List<AppInfo> packageNames);
+        void showBlockAppList(List<AppInfo> packageNames);
+
+        @UiThread
+        void showAllowAppList(List<AppInfo> packagesNames);
 
         @AnyThread
         void exit(boolean configurationChanged);

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/data/AppInfo.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/data/AppInfo.java
@@ -2,7 +2,9 @@ package io.github.trojan_gfw.igniter.exempt.data;
 
 import android.graphics.drawable.Drawable;
 
-public class AppInfo implements Cloneable {
+import java.util.Optional;
+
+public class AppInfo implements Cloneable, Comparable<AppInfo> {
     private String appName;
     private String appNameInLowercase;
     private Drawable icon;
@@ -47,6 +49,17 @@ public class AppInfo implements Cloneable {
 
     public void setExempt(boolean exempt) {
         this.exempt = exempt;
+    }
+
+    @Override
+    public int compareTo(AppInfo o) {
+        if (exempt ^ o.exempt) {
+            return exempt ? -1 : 1;
+        }
+        if (appName == null) {
+            return "".compareTo(o.appName);
+        }
+        return appName.compareTo(o.appName);
     }
 
     @Override

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/data/ExemptAppDataManager.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/data/ExemptAppDataManager.java
@@ -22,9 +22,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import io.github.trojan_gfw.igniter.Globals;
-import io.github.trojan_gfw.igniter.common.utils.FileUtils;
-
 /**
  * Implementation of {@link ExemptAppDataSource}. This class reads and writes exempted app list in a
  * file. The exempted app package names will be written line by line in the file.
@@ -39,16 +36,14 @@ import io.github.trojan_gfw.igniter.common.utils.FileUtils;
  */
 public class ExemptAppDataManager implements ExemptAppDataSource {
     private final PackageManager mPackageManager;
-    private final String mInternalExemptAppListFilePath;
-    private final String mExternalExemptAppListFilePath;
+    private final String mBlockAppListFilePath;
     private final String mAllowAppListFilePath;
 
-    public ExemptAppDataManager(Context context, String internalExemptAppListFilePath,
-                                String externalExemptAppListFilePath, String allowAppListFilePath) {
+    public ExemptAppDataManager(Context context, String blockAppListFilePath,
+                                String allowAppListFilePath) {
         super();
         mPackageManager = context.getPackageManager();
-        mInternalExemptAppListFilePath = internalExemptAppListFilePath;
-        mExternalExemptAppListFilePath = externalExemptAppListFilePath;
+        mBlockAppListFilePath = blockAppListFilePath;
         mAllowAppListFilePath = allowAppListFilePath;
     }
 
@@ -58,25 +53,8 @@ public class ExemptAppDataManager implements ExemptAppDataSource {
     }
 
     @Override
-    public void deleteExternalExemptAppInfo() {
-        new File(mExternalExemptAppListFilePath).delete();
-    }
-
-    @Override
-    public void migrateExternalExemptAppInfo() {
-        File externalSrcFile = new File(Globals.getExternalExemptedAppListPath());
-        File internalDestFile = new File(Globals.getInternalBlockAppListPath());
-        FileUtils.copy(externalSrcFile, internalDestFile);
-    }
-
-    @Override
-    public boolean checkExternalExemptAppInfoConfigExistence() {
-        return new File(mExternalExemptAppListFilePath).exists();
-    }
-
-    @Override
     public void saveBlockAppInfoSet(@Nullable Set<String> blockAppPackageNames) {
-        saveAppPackageNameSet(blockAppPackageNames, mInternalExemptAppListFilePath);
+        saveAppPackageNameSet(blockAppPackageNames, mBlockAppListFilePath);
     }
 
     private void saveAppPackageNameSet(@Nullable Set<String> packageNameSet, String filePath) {
@@ -132,7 +110,7 @@ public class ExemptAppDataManager implements ExemptAppDataSource {
 
     @Override
     public Set<String> loadBlockAppPackageNameSet() {
-        return loadAppPackageNameSet(mInternalExemptAppListFilePath);
+        return loadAppPackageNameSet(mBlockAppListFilePath);
     }
 
     private Set<String> loadAppPackageNameSet(String filePath) {

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/data/ExemptAppDataSource.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/data/ExemptAppDataSource.java
@@ -1,5 +1,6 @@
 package io.github.trojan_gfw.igniter.exempt.data;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import java.util.List;
@@ -12,17 +13,26 @@ public interface ExemptAppDataSource {
      * @return exempt applications' package names..
      */
     @WorkerThread
-    Set<String> loadExemptAppPackageNameSet();
+    Set<String> loadBlockAppPackageNameSet();
+
+    /**
+     * Load package names of applications to whom the proxy is applied.
+     */
+    @WorkerThread
+    Set<String> loadAllowAppPackageNameSet();
 
     boolean checkExternalExemptAppInfoConfigExistence();
 
     /**
      * Save exempt applications' package names.
      *
-     * @param exemptAppPackageNames exempt app package name set
+     * @param blockAppPackageNames exempt app package name set
      */
     @WorkerThread
-    void saveExemptAppInfoSet(Set<String> exemptAppPackageNames);
+    void saveBlockAppInfoSet(@Nullable Set<String> blockAppPackageNames);
+
+    @WorkerThread
+    void saveAllowAppInfoSet(@Nullable Set<String> allowAppPackageNames);
 
     /**
      * Migrate external exempted application config file to private directory.
@@ -33,6 +43,7 @@ public interface ExemptAppDataSource {
 
     /**
      * Load all application info list, including exempt apps and non-exempt apps.
+     *
      * @return all application info list
      */
     @WorkerThread

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/data/ExemptAppDataSource.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/data/ExemptAppDataSource.java
@@ -21,8 +21,6 @@ public interface ExemptAppDataSource {
     @WorkerThread
     Set<String> loadAllowAppPackageNameSet();
 
-    boolean checkExternalExemptAppInfoConfigExistence();
-
     /**
      * Save exempt applications' package names.
      *
@@ -33,13 +31,6 @@ public interface ExemptAppDataSource {
 
     @WorkerThread
     void saveAllowAppInfoSet(@Nullable Set<String> allowAppPackageNames);
-
-    /**
-     * Migrate external exempted application config file to private directory.
-     */
-    void migrateExternalExemptAppInfo();
-
-    void deleteExternalExemptAppInfo();
 
     /**
      * Load all application info list, including exempt apps and non-exempt apps.

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/fragment/ExemptAppFragment.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/fragment/ExemptAppFragment.java
@@ -24,6 +24,9 @@ import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.tabs.TabItem;
+import com.google.android.material.tabs.TabLayout;
+
 import java.util.List;
 
 import io.github.trojan_gfw.igniter.R;
@@ -42,6 +45,8 @@ public class ExemptAppFragment extends BaseFragment implements ExemptAppContract
     private RecyclerView mAppRv;
     private AppInfoAdapter mAppInfoAdapter;
     private LoadingDialog mLoadingDialog;
+    private TabItem mBlockModeTi, mAllowModeTi;
+    private TabLayout mWorkModeTl;
 
     public ExemptAppFragment() {
         // Required empty public constructor
@@ -70,6 +75,9 @@ public class ExemptAppFragment extends BaseFragment implements ExemptAppContract
     private void findViews() {
         mTopBar = findViewById(R.id.exemptAppTopBar);
         mAppRv = findViewById(R.id.exemptAppRv);
+        mBlockModeTi = findViewById(R.id.exemptAppBlockModeTi);
+        mAllowModeTi = findViewById(R.id.exemptAppAllowModeTi);
+        mWorkModeTl = findViewById(R.id.exemptAppWorkModeTabLayout);
     }
 
     private void initViews() {
@@ -90,6 +98,30 @@ public class ExemptAppFragment extends BaseFragment implements ExemptAppContract
                 mPresenter.updateAppInfo(appInfo, position, exempt);
             }
         });
+        mWorkModeTl.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
+            @Override
+            public void onTabSelected(TabLayout.Tab tab) {
+                if (tab.getPosition() == 0) { // block mode
+                    mPresenter.loadBlockAppListConfig();
+                } else {
+                    mPresenter.loadAllowAppListConfig();
+                }
+            }
+
+            @Override
+            public void onTabUnselected(TabLayout.Tab tab) {
+            }
+
+            @Override
+            public void onTabReselected(TabLayout.Tab tab) {
+            }
+        });
+    }
+
+    @Override
+    public void showAllowAppList(List<AppInfo> packagesNames) {
+        mWorkModeTl.selectTab(mWorkModeTl.getTabAt(1));
+        mAppInfoAdapter.refreshData(packagesNames);
     }
 
     @Override
@@ -166,14 +198,14 @@ public class ExemptAppFragment extends BaseFragment implements ExemptAppContract
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         dialog.dismiss();
-                        mPresenter.loadExemptedAppListConfig();
+                        mPresenter.loadBlockAppListConfig();
                     }
                 }).setNeutralButton(R.string.common_never, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 dialog.dismiss();
                 mPresenter.ignoreExternalExemptedAppListConfigForever();
-                mPresenter.loadExemptedAppListConfig();
+                mPresenter.loadBlockAppListConfig();
             }
         }).setPositiveButton(R.string.common_confirm, new DialogInterface.OnClickListener() {
             @Override
@@ -196,13 +228,14 @@ public class ExemptAppFragment extends BaseFragment implements ExemptAppContract
             if (PackageManager.PERMISSION_GRANTED == grantResults[0]) {
                 mPresenter.migrateExternalExemptedAppListFileToPrivateDirectory();
             } else {
-                mPresenter.loadExemptedAppListConfig();
+                mPresenter.loadBlockAppListConfig();
             }
         }
     }
 
     @Override
-    public void showAppList(final List<AppInfo> appInfoList) {
+    public void showBlockAppList(final List<AppInfo> appInfoList) {
+        mWorkModeTl.selectTab(mWorkModeTl.getTabAt(0));
         mAppInfoAdapter.refreshData(appInfoList);
     }
 

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/fragment/ExemptAppFragment.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/fragment/ExemptAppFragment.java
@@ -1,9 +1,7 @@
 package io.github.trojan_gfw.igniter.exempt.fragment;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.DialogInterface;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -18,7 +16,6 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -39,13 +36,11 @@ import io.github.trojan_gfw.igniter.exempt.data.AppInfo;
 
 public class ExemptAppFragment extends BaseFragment implements ExemptAppContract.View {
     public static final String TAG = "ExemptAppFragment";
-    private static final int WRITE_REQUEST = 1024;
     private ExemptAppContract.Presenter mPresenter;
     private Toolbar mTopBar;
     private RecyclerView mAppRv;
     private AppInfoAdapter mAppInfoAdapter;
     private LoadingDialog mLoadingDialog;
-    private TabItem mBlockModeTi, mAllowModeTi;
     private TabLayout mWorkModeTl;
 
     public ExemptAppFragment() {
@@ -75,8 +70,6 @@ public class ExemptAppFragment extends BaseFragment implements ExemptAppContract
     private void findViews() {
         mTopBar = findViewById(R.id.exemptAppTopBar);
         mAppRv = findViewById(R.id.exemptAppRv);
-        mBlockModeTi = findViewById(R.id.exemptAppBlockModeTi);
-        mAllowModeTi = findViewById(R.id.exemptAppAllowModeTi);
         mWorkModeTl = findViewById(R.id.exemptAppWorkModeTabLayout);
     }
 
@@ -187,50 +180,6 @@ public class ExemptAppFragment extends BaseFragment implements ExemptAppContract
                         mPresenter.exit();
                     }
                 }).create().show();
-    }
-
-    @Override
-    public void showExemptedAppListMigrationNotice() {
-        new AlertDialog.Builder(mContext)
-                .setTitle(R.string.common_alert)
-                .setMessage(R.string.exempt_app_migrate_external_exempted_app_list_msg)
-                .setNegativeButton(R.string.common_cancel, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                        mPresenter.loadBlockAppListConfig();
-                    }
-                }).setNeutralButton(R.string.common_never, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                dialog.dismiss();
-                mPresenter.ignoreExternalExemptedAppListConfigForever();
-                mPresenter.loadBlockAppListConfig();
-            }
-        }).setPositiveButton(R.string.common_confirm, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                dialog.dismiss();
-                if (ContextCompat.checkSelfPermission(mContext, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                        != PackageManager.PERMISSION_GRANTED) {
-                    requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, WRITE_REQUEST);
-                } else {
-                    mPresenter.migrateExternalExemptedAppListFileToPrivateDirectory();
-                }
-            }
-        }).show();
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (WRITE_REQUEST == requestCode) {
-            if (PackageManager.PERMISSION_GRANTED == grantResults[0]) {
-                mPresenter.migrateExternalExemptedAppListFileToPrivateDirectory();
-            } else {
-                mPresenter.loadBlockAppListConfig();
-            }
-        }
     }
 
     @Override

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/presenter/ExemptAppPresenter.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/presenter/ExemptAppPresenter.java
@@ -4,9 +4,11 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.UiThread;
+import androidx.annotation.WorkerThread;
+
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -25,8 +27,10 @@ public class ExemptAppPresenter implements ExemptAppContract.Presenter {
     private final ExemptAppDataSource mDataSource;
     private boolean mDirty;
     private boolean mConfigurationChanged;
+    private boolean mWorkInAllowMode;
     private List<AppInfo> mAllAppInfoList;
-    private Set<String> mExemptAppPackageNameSet;
+    private Set<String> mBlockAppPackageNameSet;
+    private Set<String> mAllowAppPackageNameSet;
 
     public ExemptAppPresenter(Context context, ExemptAppContract.View view, ExemptAppDataSource dataSource) {
         super();
@@ -37,41 +41,47 @@ public class ExemptAppPresenter implements ExemptAppContract.Presenter {
     }
 
     @Override
-    public void updateAppInfo(AppInfo appInfo, int position, boolean exempt) {
+    public void updateAppInfo(AppInfo appInfo, int position, boolean isChecked) {
         mDirty = true;
         String packageName = appInfo.getPackageName();
-        if (mExemptAppPackageNameSet.contains(packageName)) {
-            if (!exempt) {
-                mExemptAppPackageNameSet.remove(packageName);
+        Set<String> packageNameSet = getAppPackageNameSet(mWorkInAllowMode);
+        if (packageNameSet.contains(packageName)) {
+            if (!isChecked) {
+                packageNameSet.remove(packageName);
             }
-        } else if (exempt) {
-            mExemptAppPackageNameSet.add(packageName);
+        } else if (isChecked) {
+            packageNameSet.add(packageName);
         }
-        appInfo.setExempt(exempt);
+        appInfo.setExempt(isChecked);
+    }
+
+    @UiThread
+    private void displayAppList(List<AppInfo> appInfoList) {
+        if (mWorkInAllowMode) {
+            mView.showAllowAppList(appInfoList);
+        } else {
+            mView.showBlockAppList(appInfoList);
+        }
     }
 
     @Override
     public void filterAppsByName(final String name) {
         if (TextUtils.isEmpty(name)) {
-            mView.showAppList(mAllAppInfoList);
+            displayAppList(mAllAppInfoList);
             return;
         }
         Threads.instance().runOnWorkThread(new Task() {
             @Override
             public void onRun() {
                 final List<AppInfo> tmpInfoList = new ArrayList<>();
+                final List<AppInfo> allAppInfoList = mAllAppInfoList;
                 final String lowercaseName = name.toLowerCase();
-                for (AppInfo appInfo : mAllAppInfoList) {
+                for (AppInfo appInfo : allAppInfoList) {
                     if (appInfo.getAppNameInLowercase().contains(lowercaseName)) {
                         tmpInfoList.add(appInfo);
                     }
                 }
-                Threads.instance().runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        mView.showAppList(tmpInfoList);
-                    }
-                });
+                Threads.instance().runOnUiThread(() -> displayAppList(tmpInfoList));
             }
         });
     }
@@ -87,14 +97,15 @@ public class ExemptAppPresenter implements ExemptAppContract.Presenter {
         Threads.instance().runOnWorkThread(new Task() {
             @Override
             public void onRun() {
-                mDataSource.saveExemptAppInfoSet(mExemptAppPackageNameSet);
+                PreferenceUtils.putBooleanPreference(mContext.getContentResolver(),
+                        Uri.parse(Constants.PREFERENCE_URI),
+                        Constants.PREFERENCE_KEY_PROXY_IN_ALLOW_MODE, mWorkInAllowMode);
+                mDataSource.saveBlockAppInfoSet(mBlockAppPackageNameSet);
+                mDataSource.saveAllowAppInfoSet(mAllowAppPackageNameSet);
                 mDirty = false;
-                Threads.instance().runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        mView.dismissLoading();
-                        mView.showSaveSuccess();
-                    }
+                Threads.instance().runOnUiThread(() -> {
+                    mView.dismissLoading();
+                    mView.showSaveSuccess();
                 });
             }
         });
@@ -121,7 +132,7 @@ public class ExemptAppPresenter implements ExemptAppContract.Presenter {
             public void onRun() {
                 mDataSource.migrateExternalExemptAppInfo();
                 mDataSource.deleteExternalExemptAppInfo();
-                loadExemptedAppListConfig();
+                loadBlockAppListConfig();
             }
         });
     }
@@ -133,39 +144,60 @@ public class ExemptAppPresenter implements ExemptAppContract.Presenter {
                 false);
     }
 
-    @Override
-    public void loadExemptedAppListConfig() {
-        mView.showLoading();
-        Threads.instance().runOnWorkThread(new Task() {
-            @Override
-            public void onRun() {
-                final List<AppInfo> allAppInfoList = mDataSource.getAllAppInfoList();
-                mExemptAppPackageNameSet = mDataSource.loadExemptAppPackageNameSet();
-                for (AppInfo appInfo : allAppInfoList) {
-                    if (mExemptAppPackageNameSet.contains(appInfo.getPackageName())) {
-                        appInfo.setExempt(true);
-                    }
-                }
-                // cluster exempted apps.
-                Collections.sort(allAppInfoList, new Comparator<AppInfo>() {
-                    @Override
-                    public int compare(AppInfo o1, AppInfo o2) {
-                        if (o1.isExempt() != o2.isExempt()) {
-                            return o1.isExempt() ? -1 : 1;
-                        }
-                        return o1.getAppName().compareTo(o2.getAppName());
-                    }
-                });
-                mAllAppInfoList = allAppInfoList;
-                Threads.instance().runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        mView.showAppList(allAppInfoList);
-                        mView.dismissLoading();
-                    }
-                });
+    private void showViewLoading() {
+        Threads.instance().runOnUiThread(mView::showLoading);
+    }
+
+    private Set<String> getAppPackageNameSet(boolean workInAllowMode) {
+        if (workInAllowMode) {
+            if (mAllowAppPackageNameSet == null) {
+                mAllowAppPackageNameSet = mDataSource.loadAllowAppPackageNameSet();
             }
+            return mAllowAppPackageNameSet;
+        } else {
+            if (mBlockAppPackageNameSet == null) {
+                mBlockAppPackageNameSet = mDataSource.loadBlockAppPackageNameSet();
+            }
+            return mBlockAppPackageNameSet;
+        }
+    }
+
+    @WorkerThread
+    private void loadAppListConfigInner(boolean inAllowMode) {
+        showViewLoading();
+        if (mAllAppInfoList == null) {
+            mAllAppInfoList = mDataSource.getAllAppInfoList();
+        }
+        List<AppInfo> allAppInfoList = mAllAppInfoList;
+        Set<String> packageNameSet = getAppPackageNameSet(inAllowMode);
+        for (AppInfo appInfo : allAppInfoList) {
+            appInfo.setExempt(packageNameSet.contains(appInfo.getPackageName()));
+        }
+        Collections.sort(allAppInfoList, AppInfo::compareTo);
+        Threads.instance().runOnUiThread(()->{
+            if (inAllowMode) {
+                mView.showAllowAppList(allAppInfoList);
+            } else {
+                mView.showBlockAppList(allAppInfoList);
+            }
+            mView.dismissLoading();
         });
+    }
+
+    @Override
+    public void loadAllowAppListConfig() {
+        if (mWorkInAllowMode) return;
+        mDirty = true;
+        mWorkInAllowMode = true;
+        loadAppListConfigInner(true);
+    }
+
+    @Override
+    public void loadBlockAppListConfig() {
+        if (!mWorkInAllowMode) return;
+        mDirty = true;
+        mWorkInAllowMode = false;
+        loadAppListConfigInner(false);
     }
 
     private boolean needCheckExternalExemptedAppListConfig() {
@@ -174,13 +206,24 @@ public class ExemptAppPresenter implements ExemptAppContract.Presenter {
                 true);
     }
 
+    private void loadWorkModeAndAppListConfig() {
+        Threads.instance().runOnWorkThread(new Task() {
+            @Override
+            public void onRun() {
+                mWorkInAllowMode = PreferenceUtils.getBooleanPreference(mContext.getContentResolver(),
+                        Uri.parse(Constants.PREFERENCE_URI), Constants.PREFERENCE_KEY_PROXY_IN_ALLOW_MODE, false);
+                loadAppListConfigInner(mWorkInAllowMode);
+            }
+        });
+    }
+
     @Override
     public void start() {
         if (needCheckExternalExemptedAppListConfig() &&
                 mDataSource.checkExternalExemptAppInfoConfigExistence()) {
             mView.showExemptedAppListMigrationNotice();
         } else {
-            loadExemptedAppListConfig();
+            loadWorkModeAndAppListConfig();
         }
     }
 }

--- a/app/src/main/res/layout/fragment_exempt_app.xml
+++ b/app/src/main/res/layout/fragment_exempt_app.xml
@@ -13,9 +13,30 @@
         android:layout_height="@dimen/top_bar_height"
         tools:ignore="MissingConstraints" />
 
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/exemptAppWorkModeTabLayout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/exemptAppTopBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" >
+
+        <com.google.android.material.tabs.TabItem
+            android:id="@+id/exemptAppBlockModeTi"
+            android:text="@string/exempt_app_mode_block"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <com.google.android.material.tabs.TabItem
+            android:id="@+id/exemptAppAllowModeTi"
+            android:text="@string/exempt_app_mode_allow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.tabs.TabLayout>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/exemptAppRv"
-        app:layout_constraintTop_toBottomOf="@id/exemptAppTopBar"
+        app:layout_constraintTop_toBottomOf="@id/exemptAppWorkModeTabLayout"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -92,4 +92,6 @@
     <string name="trojan_service_not_available">Trojan 服务不可用</string>
     <string name="trojan_service_error">Trojan 服务错误</string>
     <string name="proxy_service_not_connected">代理服务暂未开启</string>
+    <string name="exempt_app_mode_allow">代理应用模式</string>
+    <string name="exempt_app_mode_block">屏蔽应用模式</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,8 @@
         External exempted app list configuration file detected,
         would you like to migrate it?
     </string>
+    <string name="exempt_app_mode_allow">Allow Mode</string>
+    <string name="exempt_app_mode_block">Block Mode</string>
     <string name="action_save_profile">Save Server</string>
     <string name="action_sharelink">Share Link</string>
     <string name="title_activity_about">About</string>


### PR DESCRIPTION
Now Igniter is able to exempt apps in two ways: Block mode and allow mode.
While in block mode, checked applications are not allowed to go through proxy.
In allow mode, only checked applications are allowed to go through proxy.

Also remove the code that is related to external exempt application list configuration. As the setting of exempting app is simplified, I think it is unnecessary to migrate external configuration. 