### PR TITLE
Server list bugfix

### DIFF
--- a/app/src/main/java/io/github/trojan_gfw/igniter/servers/presenter/ServerListPresenter.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/servers/presenter/ServerListPresenter.java
@@ -164,6 +164,7 @@ public class ServerListPresenter implements ServerListContract.Presenter {
     @Override
     public void exitServerListBatchOperation() {
         mView.hideServerListBatchOperation();
+        mBatchDeleteConfigSet.clear();
     }
 
     @Override


### PR DESCRIPTION
When user exit the batch operation mode in `ServerListFragment`, `ServerListPresenter` does not clear the `mBatchDeleteConfigSet`, which may influence the next batch operation.