### PR TITLE
Crash fix

### DIFF
--- a/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
@@ -12,8 +12,10 @@ import android.os.Bundle;
 import android.os.RemoteException;
 import android.text.InputType;
 import android.text.method.LinkMovementMethod;
+import android.view.GestureDetector;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
@@ -38,6 +40,7 @@ import java.io.InputStream;
 import io.github.trojan_gfw.igniter.common.constants.Constants;
 import io.github.trojan_gfw.igniter.common.os.Task;
 import io.github.trojan_gfw.igniter.common.os.Threads;
+import io.github.trojan_gfw.igniter.common.utils.AnimationUtils;
 import io.github.trojan_gfw.igniter.common.utils.PreferenceUtils;
 import io.github.trojan_gfw.igniter.common.utils.SnackbarUtils;
 import io.github.trojan_gfw.igniter.connection.TrojanConnection;
@@ -369,6 +372,25 @@ public class MainActivity extends AppCompatActivity implements TrojanConnection.
                         Constants.PREFERENCE_KEY_FIRST_START, false);
             }
         });
+        View horseIv = findViewById(R.id.imageView);
+        GestureDetector gestureDetector = new GestureDetector(this, new GestureDetector.SimpleOnGestureListener() {
+            @Override
+            public boolean onDown(MotionEvent e) {
+                return true;
+            }
+            @Override
+            public boolean onDoubleTap(MotionEvent e) {
+                swayTheHorse();
+                return true;
+            }
+        });
+        horseIv.setOnTouchListener((v, event) -> gestureDetector.onTouchEvent(event));
+    }
+
+    private void swayTheHorse() {
+        View v = findViewById(R.id.imageView);
+        v.clearAnimation();
+        AnimationUtils.sway(v, 60f, 500L, 4f);
     }
 
     @Override

--- a/app/src/main/java/io/github/trojan_gfw/igniter/common/utils/AnimationUtils.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/common/utils/AnimationUtils.java
@@ -1,0 +1,54 @@
+package io.github.trojan_gfw.igniter.common.utils;
+
+import android.view.View;
+import android.view.animation.AccelerateDecelerateInterpolator;
+import android.view.animation.Animation;
+import android.view.animation.AnimationSet;
+import android.view.animation.RotateAnimation;
+
+public class AnimationUtils {
+    /**
+     * Perform an sway animation on view. The view would start swaying from 0° to (<code>maxSwayPeriodDuration / 2</code>°) clockwise.
+     * Then it sways to the axisymmetric position (in respect to the vertical center axis of the view) and sways back.
+     * The view will keep swaying till the <code>nextDegree</code> reaches 0.
+     * Each time the sway amplitude is decreased by {@param swayDegreeDecrementStep}.
+     *
+     * @param view                    The view to be animated
+     * @param maxSwayDegree           Maximum sway amplitude.
+     * @param maxSwayPeriodDuration   The sway duration for maximum sway amplitude.
+     * @param swayDegreeDecrementStep Step of sway amplitude decrement. Must be larger than 0.
+     */
+    public static void sway(View view, float maxSwayDegree, long maxSwayPeriodDuration, float swayDegreeDecrementStep) {
+        if (Float.compare(swayDegreeDecrementStep, 0f) <= 0) {
+            throw new IllegalArgumentException("swayDegreeDecrementStep must be >= 0!");
+        }
+        AnimationSet rotateSet = new AnimationSet(true);
+        rotateSet.setInterpolator(new AccelerateDecelerateInterpolator());
+        float lastDegree = maxSwayDegree / 2f;
+        Animation prepareAnim = new RotateAnimation(0f, lastDegree, Animation.RELATIVE_TO_SELF, .5f, Animation.RELATIVE_TO_SELF, .5f);
+        prepareAnim.setDuration(maxSwayPeriodDuration >> 1);
+        rotateSet.addAnimation(prepareAnim);
+        long startOffSet = maxSwayPeriodDuration >> 1;
+        boolean run = true;
+        while (run) {
+            float nextDegree;
+            if (lastDegree > 0f) {
+                nextDegree = -lastDegree;
+            } else {
+                nextDegree = -lastDegree - swayDegreeDecrementStep;
+                if (Float.compare(nextDegree, 0f) <= 0) {
+                    run = false;
+                }
+            }
+            double degreeDistance = Math.abs(lastDegree) + Math.abs(nextDegree);
+            long duration = (long) ((degreeDistance / maxSwayDegree) * maxSwayPeriodDuration);
+            Animation rotate = new RotateAnimation(lastDegree, nextDegree, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f);
+            rotate.setDuration(duration);
+            rotate.setStartOffset(startOffSet);
+            startOffSet += duration;
+            lastDegree = nextDegree;
+            rotateSet.addAnimation(rotate);
+        }
+        view.startAnimation(rotateSet);
+    }
+}

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/fragment/ExemptAppFragment.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/fragment/ExemptAppFragment.java
@@ -192,6 +192,8 @@ public class ExemptAppFragment extends BaseFragment implements ExemptAppContract
     public void showLoading() {
         if (mLoadingDialog == null) {
             mLoadingDialog = new LoadingDialog(requireContext());
+            mLoadingDialog.setCancelable(false);
+            mLoadingDialog.setCanceledOnTouchOutside(false);
             mLoadingDialog.setMsg(getString(R.string.exempt_app_loading_tip));
         }
         mLoadingDialog.show();

--- a/app/src/main/java/io/github/trojan_gfw/igniter/exempt/presenter/ExemptAppPresenter.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/exempt/presenter/ExemptAppPresenter.java
@@ -4,12 +4,14 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.WorkerThread;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import io.github.trojan_gfw.igniter.common.constants.Constants;
@@ -55,7 +57,10 @@ public class ExemptAppPresenter implements ExemptAppContract.Presenter {
     }
 
     @UiThread
-    private void displayAppList(List<AppInfo> appInfoList) {
+    private void displayAppList(@Nullable List<AppInfo> appInfoList) {
+        if (appInfoList == null) {
+            appInfoList = Collections.emptyList();
+        }
         if (mWorkInAllowMode) {
             mView.showAllowAppList(appInfoList);
         } else {

--- a/app/src/main/java/io/github/trojan_gfw/igniter/servers/data/ServerListDataManager.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/servers/data/ServerListDataManager.java
@@ -3,6 +3,7 @@ package io.github.trojan_gfw.igniter.servers.data;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,11 +16,13 @@ import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -166,17 +169,17 @@ public class ServerListDataManager implements ServerListDataSource {
                 idxOfSharp = i;
             } else if (c == '\n') {
                 idxOfLineEnd = i;
-            }
-            if (idxOfSharp != -1 && idxOfLineEnd != -1) {
-                String trojanUrl = configLines.substring(idxOfLineStart, idxOfSharp);
-                String remark = configLines.substring(idxOfSharp + 1, idxOfLineEnd).trim();
-                TrojanConfig config = TrojanURLHelper.ParseTrojanURL(trojanUrl);
-                if (config != null) {
-                    config.setRemoteServerRemark(remark);
-                    configMap.put(config.getRemoteAddr(), config);
+                if (idxOfSharp != -1) {
+                    String trojanUrl = configLines.substring(idxOfLineStart, idxOfSharp);
+                    String remark = configLines.substring(idxOfSharp + 1, idxOfLineEnd).trim();
+                    TrojanConfig config = TrojanURLHelper.ParseTrojanURL(trojanUrl);
+                    if (config != null) {
+                        config.setRemoteServerRemark(remark);
+                        configMap.put(config.getRemoteAddr(), config);
+                    }
                 }
                 idxOfLineStart = idxOfLineEnd + 1;
-                idxOfLineEnd = idxOfSharp = -1;
+                idxOfSharp = -1;
             }
         }
         List<TrojanConfig> previousList = loadServerConfigList();


### PR DESCRIPTION
- Set LoadingDialog uncancelable in ExemptAppFragment. User cannot touch SearchView in ExemptAppFragment until loading is finshed. Also add null access protection in ExemptAppPresenter. Fix the NullPointerException thrown by accessing null app list.
- Refine subscription parsing in ServerListDataManager. Fix the exception thrown by parsing invalid data from subscription.
- Add an easter egg on MainActivity. Double tap the horse would see that.