### PR TITLE
Code refinement

### DIFF
--- a/app/src/main/java/io/github/trojan_gfw/igniter/ProxyService.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/ProxyService.java
@@ -119,7 +119,8 @@ public class ProxyService extends VpnService implements TestConnection.OnResultL
                 onResult(TUN2SOCKS5_SERVER_HOST, false, 0L, getString(R.string.proxy_service_not_connected));
                 return;
             }
-            new TestConnection(TUN2SOCKS5_SERVER_HOST, tun2socksPort, ProxyService.this).execute(testUrl);
+            new Thread(()-> new TestConnection(TUN2SOCKS5_SERVER_HOST, tun2socksPort,
+                    ProxyService.this).testLatency(testUrl)).start();
         }
 
         @Override

--- a/app/src/main/java/io/github/trojan_gfw/igniter/common/dialog/LoadingDialog.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/common/dialog/LoadingDialog.java
@@ -4,6 +4,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.ColorDrawable;
 import android.view.Window;
 import android.widget.TextView;
@@ -29,8 +30,9 @@ public class LoadingDialog extends Dialog {
         }
         setContentView(R.layout.dialog_loading);
         ContentLoadingProgressBar pb = findViewById(R.id.dialogLoadingPb);
-        pb.getIndeterminateDrawable().setColorFilter(ContextCompat.getColor(context, R.color.colorPrimary),
-                PorterDuff.Mode.MULTIPLY);
+        pb.getIndeterminateDrawable().setColorFilter(
+                new PorterDuffColorFilter(ContextCompat.getColor(context, R.color.colorPrimary),
+                PorterDuff.Mode.MULTIPLY));
         mMsgTv = findViewById(R.id.dialogLoadingMsgTv);
     }
 

--- a/app/src/main/java/io/github/trojan_gfw/igniter/connection/TestConnection.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/connection/TestConnection.java
@@ -1,6 +1,5 @@
 package io.github.trojan_gfw.igniter.connection;
 
-import java.lang.ref.WeakReference;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
@@ -10,12 +9,12 @@ public class TestConnection {
     private static final int DEFAULT_TIMEOUT = 10 * 1000; // 10 seconds
     private final String mProxyHost;
     private final long mProxyPort;
-    private final WeakReference<OnResultListener> mOnResultListenerRef;
+    private final OnResultListener mOnResultListener;
 
     public TestConnection(String proxyHost, long proxyPort, OnResultListener onResultListener) {
         mProxyHost = proxyHost;
         mProxyPort = proxyPort;
-        mOnResultListenerRef = new WeakReference<>(onResultListener);
+        mOnResultListener = onResultListener;
     }
 
     public void testLatency(String testUrl) {
@@ -27,16 +26,9 @@ public class TestConnection {
             connection.setConnectTimeout(DEFAULT_TIMEOUT);
             connection.setReadTimeout(DEFAULT_TIMEOUT);
             connection.connect();
-            postResult(testUrl, true, "", System.currentTimeMillis() - startTime);
+            mOnResultListener.onResult(testUrl, true, System.currentTimeMillis() - startTime, "");
         } catch (Exception e) {
-            postResult(testUrl, false, e.getMessage(), 0L);
-        }
-    }
-
-    private void postResult(String url, boolean connected, String error, long latency) {
-        OnResultListener listener = mOnResultListenerRef.get();
-        if (listener != null) {
-            listener.onResult(url, connected, latency, error);
+            mOnResultListener.onResult(testUrl, false, 0L, e.getMessage());
         }
     }
 

--- a/app/src/main/java/io/github/trojan_gfw/igniter/connection/TestConnection.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/connection/TestConnection.java
@@ -1,16 +1,12 @@
 package io.github.trojan_gfw.igniter.connection;
 
-import android.os.AsyncTask;
-
-import androidx.annotation.NonNull;
-
 import java.lang.ref.WeakReference;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
 
-public class TestConnection extends AsyncTask<String, Void, TestResult> {
+public class TestConnection {
     private static final int DEFAULT_TIMEOUT = 10 * 1000; // 10 seconds
     private final String mProxyHost;
     private final long mProxyPort;
@@ -22,9 +18,7 @@ public class TestConnection extends AsyncTask<String, Void, TestResult> {
         mOnResultListenerRef = new WeakReference<>(onResultListener);
     }
 
-    @Override
-    protected TestResult doInBackground(String... strings) {
-        String testUrl = strings[0];
+    public void testLatency(String testUrl) {
         try {
             long startTime = System.currentTimeMillis();
             InetSocketAddress proxyAddress = new InetSocketAddress(mProxyHost, (int) mProxyPort);
@@ -33,36 +27,20 @@ public class TestConnection extends AsyncTask<String, Void, TestResult> {
             connection.setConnectTimeout(DEFAULT_TIMEOUT);
             connection.setReadTimeout(DEFAULT_TIMEOUT);
             connection.connect();
-            return new TestResult(testUrl, true, "",
-                    System.currentTimeMillis() - startTime);
+            postResult(testUrl, true, "", System.currentTimeMillis() - startTime);
         } catch (Exception e) {
-            return new TestResult(testUrl, false, e.getMessage(), 0);
+            postResult(testUrl, false, e.getMessage(), 0L);
         }
     }
 
-    @Override
-    protected void onPostExecute(TestResult testResult) {
+    private void postResult(String url, boolean connected, String error, long latency) {
         OnResultListener listener = mOnResultListenerRef.get();
         if (listener != null) {
-            listener.onResult(testResult.url, testResult.connected, testResult.delay, testResult.error);
+            listener.onResult(url, connected, latency, error);
         }
     }
 
     public interface OnResultListener {
         void onResult(String testUrl, boolean connected, long delay, String error);
-    }
-}
-
-class TestResult {
-    boolean connected;
-    String url;
-    String error;
-    long delay;
-
-    TestResult(String url, boolean connected, @NonNull String error, long delay) {
-        this.connected = connected;
-        this.url = url;
-        this.error = error;
-        this.delay = delay;
     }
 }


### PR DESCRIPTION
- Fix deprecation warning on build. Use `PorterDuffColorFilter` in `LoadingDialog`, deprecate `AsyncTask` in `TestConnection`.
- Fix a bad design in TestConnection. Replace the field  `WeakReference<OnResultListener>` with field  `OnResultListener`. A task runner should not care about whether the listener would cause memory leaking. It only matters to the caller.