### PR TITLE
Fix the "DNS" text invisible issue while in night mode.

### DIFF
--- a/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
@@ -60,7 +60,7 @@ import io.github.trojan_gfw.igniter.tile.ProxyHelper;
 
 public class MainActivity extends AppCompatActivity implements TrojanConnection.Callback {
     private static final String TAG = "MainActivity";
-    private static final long INVALID_PORT = 0;
+    private static final long INVALID_PORT = -1L;
     private static final String CONNECTION_TEST_URL = "https://www.google.com";
 
     private String shareLink;
@@ -568,11 +568,11 @@ public class MainActivity extends AppCompatActivity implements TrojanConnection.
     @UiThread
     private void updatePortInfo(long port) {
         currentProxyPort = port;
-        if (INVALID_PORT == port) {
-            copyPortBtn.setVisibility(View.INVISIBLE);
-        } else {
+        if (port >= 0L && port <= 65535) {
             copyPortBtn.setText(getString(R.string.notification_listen_port, String.valueOf(port)));
             copyPortBtn.setVisibility(View.VISIBLE);
+        } else {
+            copyPortBtn.setVisibility(View.INVISIBLE);
         }
     }
 

--- a/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/MainActivity.java
@@ -60,10 +60,6 @@ import io.github.trojan_gfw.igniter.tile.ProxyHelper;
 
 public class MainActivity extends AppCompatActivity implements TrojanConnection.Callback {
     private static final String TAG = "MainActivity";
-    private static final int READ_WRITE_EXT_STORAGE_PERMISSION_REQUEST = 514;
-    private static final int VPN_REQUEST_CODE = 233;
-    private static final int SERVER_LIST_CHOOSE_REQUEST_CODE = 1024;
-    private static final int EXEMPT_APP_CONFIGURE_REQUEST_CODE = 2077;
     private static final long INVALID_PORT = 0;
     private static final String CONNECTION_TEST_URL = "https://www.google.com";
 

--- a/app/src/main/java/io/github/trojan_gfw/igniter/ProxyService.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/ProxyService.java
@@ -76,7 +76,7 @@ public class ProxyService extends VpnService implements TestConnection.OnResultL
     public static final int STOPPING = 2;
     public static final int STOPPED = 3;
     public static final int IGNITER_STATUS_NOTIFY_MSG_ID = 114514;
-    private static final long INVALID_PORT = 0L;
+    private static final long INVALID_PORT = -1L;
     public long tun2socksPort = INVALID_PORT;
     public boolean enable_clash = false;
     public boolean allowLan = false;

--- a/app/src/main/java/io/github/trojan_gfw/igniter/connection/TrojanConnection.java
+++ b/app/src/main/java/io/github/trojan_gfw/igniter/connection/TrojanConnection.java
@@ -11,6 +11,7 @@ import android.os.Looper;
 import android.os.RemoteException;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.UiThread;
 
 import io.github.trojan_gfw.igniter.ProxyService;
 import io.github.trojan_gfw.igniter.R;
@@ -84,8 +85,10 @@ public class TrojanConnection implements ServiceConnection, Binder.DeathRecipien
 
         void onServiceDisconnected();
 
+        @UiThread
         void onStateChanged(int state, String msg);
 
+        @UiThread
         void onTestResult(String testUrl, boolean connected, long delay, @NonNull String error);
 
         void onBinderDied();

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -139,5 +139,18 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/allowLanSwitch" />
 
+        <Button
+            android:id="@+id/copyPortBtn"
+            app:layout_constraintTop_toBottomOf="@id/startStopButton"
+            app:layout_constraintStart_toStartOf="@id/startStopButton"
+            app:layout_constraintEnd_toEndOf="@id/startStopButton"
+            android:layout_margin="@dimen/main_btn_margin"
+            tools:text="Listening on port: 40199"
+            android:visibility="invisible"
+            tools:visibility="visible"
+            android:textSize="@dimen/text_size"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/main_btn_height" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_main_720.xml
+++ b/app/src/main/res/layout/activity_main_720.xml
@@ -140,5 +140,18 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/allowLanSwitch" />
 
+        <Button
+            android:id="@+id/copyPortBtn"
+            app:layout_constraintTop_toBottomOf="@id/startStopButton"
+            app:layout_constraintStart_toStartOf="@id/startStopButton"
+            app:layout_constraintEnd_toEndOf="@id/startStopButton"
+            android:layout_margin="@dimen/main_btn_margin"
+            tools:text="Listening on port: 40199"
+            android:visibility="invisible"
+            tools:visibility="visible"
+            android:textSize="@dimen/text_size_small"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/main_btn_height" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -32,8 +32,6 @@
             <androidx.cardview.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@android:color/white"
-                app:cardBackgroundColor="@android:color/white"
                 app:cardCornerRadius="@dimen/settings_card_corner_radius"
                 app:cardPreventCornerOverlap="true"
                 app:cardUseCompatPadding="true"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -121,4 +121,6 @@
     <string name="settings_dns_format_error">非法DNS</string>
     <string name="common_save">保存</string>
     <string name="settings_title">设置</string>
+    <string name="notification_listen_port">代理端口: %1$s</string>
+    <string name="main_proxy_port_copied_to_clipboard">代理端口 %1$s 已复制到剪贴板</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="notification_channel_id" translatable="false">igniter_notify_chan</string>
     <string name="notification_channel_name">Igniter notifications</string>
     <string name="notification_starting_service">Starting service</string>
+    <string name="notification_listen_port">listening on port: %1$s</string>
     <string name="main_restart_proxy_service_tip">Restart proxy yourself to apply new exempt apps configuration.</string>
     <string name="clipboard_import_tip">Do you want to import the Trojan URL you just copied?</string>
 
@@ -60,6 +61,7 @@
     <string name="server_list_lack_of_read_permission">Lack of read external storage permission!</string>
     <string name="main_save_success">@string/common_save_success</string>
     <string name="main_save_failed">Save failed</string>
+    <string name="main_proxy_port_copied_to_clipboard">Proxy port %1$s copied to clipboard</string>
 
     <string name="main_write_external_storage_permission_requirement">
         Igniter needs to read and write external storage for reading or writing exempted app


### PR DESCRIPTION
By default, the color of `TextView` would be changed to white while the app is in night mode, which makes the text invisible in  white background.
As Android provides a default color schemes of views for night mode, simply using the default scheme should work.

- Use default background color of `CardView` in Settings, fixing the text color issue in night mode.
- Add a button in `MainActivity` for displaying proxy port, clicking the button would copy the port to clipboard.